### PR TITLE
Changing device-name to HENNESSY

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Proprietary blob for Redmi Note 2 (Hermes)
+# Proprietary blob for Redmi Note 3 (HENNESSY)
 
 ### Other resource:
-  - Device tree https://github.com/jianminglok/android_device_xiaomi_hermes
+  - Device tree https://github.com/jianminglok/android_device_xiaomi_hennessy
   - Kernel source: Not released yet
 
 ### Credits (Sort by alphabetical order):


### PR DESCRIPTION
This is just a minor change that will not change any behavior but should help avoid confusion (before: mix of Redmi Note 3 Hennessy and Remi Note 2 Hermes)